### PR TITLE
prototype_source/skip_param_init 번역 (#21)

### DIFF
--- a/prototype_source/skip_param_init.rst
+++ b/prototype_source/skip_param_init.rst
@@ -1,35 +1,31 @@
-Skipping Module Parameter Initialization
+모듈 매개변수 초기화 건너뛰기
 ========================================
 
-Introduction
+소개
 ------------
 
-When a module is created, its learnable parameters are initialized according
-to a default initialization scheme associated with the module type. For example, the `weight`
-parameter for a :class:`torch.nn.Linear` module is initialized from a
-`uniform(-1/sqrt(in_features), 1/sqrt(in_features))` distribution. If some other initialization
-scheme is desired, this has traditionally required re-initializing the parameters
-after module instantiation:
+모듈이 생성될 때, 모듈 유형과 관련된 기본 초기화 스킴에 따라 학습 가능한 매개변수가 초기화됩니다.
+예를 들어, :class:`torch.nn.Linear` 모듈의 `가중치` 매개변수는 
+`uniform(-1/sqrt(in_features), 1/sqrt(in_features))` 분포로 초기화 됩니다.
+기존에는 다른 초기화 스킴이 필요한 경우 모듈 인스턴스화 후 매개변수를 재초기화해야 했습니다.
 
 ::
 
     from torch import nn
 
-    # Initializes weight from the default distribution: uniform(-1/sqrt(10), 1/sqrt(10)).
+    # 기본 분포로 가중치를 초기화합니다: uniform(-1/sqrt(10), 1/sqrt(10)).
     m = nn.Linear(10, 5)
 
-    # Re-initialize weight from a different distribution.
+    # 다른 분포로 가중치를 재초기화합니다.
     nn.init.orthogonal_(m.weight)
 
-In this case, the initialization done during construction is wasted computation, and it may be non-trivial if
-the `weight` parameter is large.
+이 경우 구성 중 수행되는 초기화는 계산 낭비이며, `가중치` 매개변수가 크면 사소한 문제가 아닐 수 있습니다.
 
-Skipping Initialization
+초기화 건너뛰기
 -----------------------
 
-It is now possible to skip parameter initialization during module construction, avoiding
-wasted computation. This is easily accomplished using the :func:`torch.nn.utils.skip_init` function:
-
+모듈 구성 중 매개변수 초기화를 건너뛰게 되어 낭비되는 계산을 피할 수 있습니다.
+:func:`torch.nn.utils.skip_init` 함수를 사용하여 쉽게 실행할 수 있습니다.
 ::
 
     from torch import nn
@@ -37,31 +33,29 @@ wasted computation. This is easily accomplished using the :func:`torch.nn.utils.
 
     m = skip_init(nn.Linear, 10, 5)
 
-    # Example: Do custom, non-default parameter initialization.
+    # 예제 : 기본 이외의 매개변수 초기화를 커스텀하여 실행합니다.
     nn.init.orthogonal_(m.weight)
 
-This can be applied to any module that satisfies the conditions described in the
-:ref:`Updating` section below. Note that all modules provided by
-`torch.nn` satisfy these conditions and thus support skipping init.
+아래 :ref:`Updating` 섹션에 설명된 조건을 충족하는 모듈에 적용할 수 있습니다.
+`torch.nn` 에 있는 모든 모듈은 조건을 충족하기 때문에 초기화 스킵을 지원하고 있습니다.
 
 .. _Updating:
 
-Updating Modules to Support Skipping Initialization
+초기화 건너뛰기를 위한 모듈 업데이트
 ---------------------------------------------------
 
-Due to the way :func:`torch.nn.utils.skip_init` is implemented (see :ref:`Details`), there are
-two requirements that a module must meet to be compatible with the function.
-You can opt in to the parameter initialization skipping functionality for your custom module
-simply by adhering to these requirements:
+:func:`torch.nn.utils.skip_init` 의 구현(참고 :ref:`Details`) 방법에 따라,
+모듈이 함수와 호환되기 위한 두 가지 요구사항이 있습니다.
+다음의 요구사항을 이행하면 커스텀 모듈의 매개변수 초기화 스킵 기능을 선택할 수 있습니다:
 
-  1. The module must accept a `device` kwarg in its constructor that is passed to any parameters
-  or buffers created during construction.
+  1. 모듈을 생성할 때 매개변수와 버퍼로 전달되는 모듈의 생성자 내 `device` kwarg를 
+  사용해야 합니다. 
 
-  2. The module must not perform any computation on parameters or buffers in its constructor except
-  initialization (i.e. functions from `torch.nn.init`).
+  2. 모듈은 초기화를 제외하고 모듈의 생성자 내 매개변수 또는 버퍼 계산을 수행하지 않아야 합니다
+  (i.e. `torch.nn.init`의 함수).
 
-The following example demonstrates a module updated to support the `device`
-kwarg by passing it along to any created parameters, buffers, or submodules:
+다음 예시는 작성된 매개변수, 버퍼 또는 서브모듈에 `device` kwarg를 전달하여 지원하도록 
+모듈이 업데이트 된 것을 나태냅니다:
 
 ::
 
@@ -72,21 +66,21 @@ kwarg by passing it along to any created parameters, buffers, or submodules:
       def __init__(self, foo, bar, device=None):
         super().__init__()
 
-        # ==== Case 1: Module creates parameters directly. ====
-        # Pass device along to any created parameters.
+        # ==== 사례 1: 모듈 매개변수를 직접 생성합니다. ====
+        # 생성한 매개변수에 device를 전달합니다.
         self.param1 = nn.Parameter(torch.empty((foo, bar), device=device))
         self.register_parameter('param2', nn.Parameter(torch.empty(bar, device=device)))
 
-        # To ensure support for the meta device, avoid using ops except those in
-        # torch.nn.init on parameters in your module's constructor.
+        # 메타 device 지원을 확실히 하기 위해 모듈의 생성자 내 매개변수에
+        # torch.nn.init의 ops 외에는 사용하지 마십시오.
         with torch.no_grad():
             nn.init.kaiming_uniform_(self.param1)
             nn.init.uniform_(self.param2)
 
 
-        # ==== Case 2: Module creates submodules. ====
-        # Pass device along recursively. All submodules will need to support
-        # them as well; this is the case for all torch.nn provided modules.
+        # ==== 사례 2: 모듈의 서브모듈을 생성합니다. ====
+        # 모든 서브 모듈은 device를 재귀적으로 전달해야 합니다.
+        # torch.nn 모듈 예시입니다.
         self.fc = nn.Linear(bar, 5, device=device)
 
         # This also works with containers.
@@ -96,32 +90,31 @@ kwarg by passing it along to any created parameters, buffers, or submodules:
         )
 
 
-        # ==== Case 3: Module creates buffers. ====
-        # Pass device along during buffer tensor creation.
+        # ==== 사례 3: 모듈의 버퍼를 생성합니다. ====
+        # 버퍼 tensor 생성 동안 device를 전달합니다.
         self.register_buffer('some_buffer', torch.ones(7, device=device))
 
     ...
 
 .. _Details:
 
-Implementation Details
+구현 세부사항
 ----------------------
 
-Behind the scenes, the :func:`torch.nn.utils.skip_init` function is implemented in terms of a two-step pattern:
+다음으로 :func:`torch.nn.utils.skip_init` 함수는 2단계 패턴으로 구현됩니다.
 
 ::
 
-    # 1. Initialize module on the meta device; all torch.nn.init ops have
-    # no-op behavior on the meta device.
+    # 1. 메타 device 에서 모듈을 초기화합니다; 모든 torch.nn.init ops는 
+    # 메타 device에서 no-op 동작을 합니다.
     m = nn.Linear(10, 5, device='meta')
 
-    # 2. Materialize an uninitialized (empty) form of the module on the CPU device.
-    # The result of this is a module instance with uninitialized parameters.
+    # 2. 초기화되지 않은(빈) 형태의 모듈을 CPU device에 구현합니다.
+    # 결과는 초기화 되지 않은 매개 변수를 가진 모듈 인스턴스입니다.
     m.to_empty(device='cpu')
 
-It works by instantiating the module onto a "meta" device, which has tensor shape information
-but does not allocate any storage. The `torch.nn.init` ops are specially implemented for this meta device
-so that they have no-op behavior. This results in the parameter intialization logic being essentially skipped.
+모듈은 "메타" device로 인스턴스화하여 동작합니다. tensor shape 정보를 가지고 있지만 스토리지는 할당하지 않습니다.
+`torch.nn.init` ops는 메타 device를 위해 특별히 구현되어 있고 no-op 동작을 합니다.
+이로 인해 매개변수 초기화 로직에서 본질적으로 건너뛰게 됩니다.
 
-Note that this pattern only works for modules that properly support a `device` kwarg during construction, as
-described in :ref:`Updating`.
+:ref:`Updating` 에 설명된 대로 이 패턴은 모듈 구성 중 `device` kwarg를 적절히 지원하여 모듈에서만 작동 합니다.


### PR DESCRIPTION
관련 이슈 번호
============
- 이슈 번호: #21  

PR 종류
============

- [ ] 오탈자를 수정하거나 번역을 개선하는 기여
- [x] 번역되지 않은 튜토리얼을 번역하는 기여
- [ ] 공식 튜토리얼 내용을 반영하는 기여
- [ ] 위 종류에 포함되지 않는 기여

PR 설명
============
prototype_source 폴더의 [skip_param_init](https://github.com/hyoyoung/22-tutorials-ex/blob/master/prototype_source/skip_param_init.rst) 파일을 번역하였습니다.

잘 모르겠는 부분도 있었지만 한 페이지를 전부 번역해봤습니다!
번역 후 빌드하여 이상하게 출력되는 부분이 없는지 확인하였습니다.